### PR TITLE
Some smaller fixes for warnings, deprecations and bugs

### DIFF
--- a/action.php
+++ b/action.php
@@ -1,9 +1,5 @@
 <?php
-// must be run within DokuWiki
-if(!defined('DOKU_INC')) die();
 
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'syntax.php';
 
 /**
  * All DokuWiki plugins to extend the parser/rendering mechanism

--- a/action.php
+++ b/action.php
@@ -127,15 +127,11 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 	    $event->preventDefault();
 	    $event->stopPropagation();
 
-
-
-	    $json = new JSON();
-
 	    list($dtable_start_line, $dtable_page_id) = explode('_', $_POST['table'], 2);
 	    $file = wikiFN( $dtable_page_id );
 	    if( ! @file_exists( $file  ) )
 	    {
-			echo $json->encode( array('type' => 'error', 'msg' => 'This page does not exist.') );
+			echo json_encode( array('type' => 'error', 'msg' => 'This page does not exist.') );
 			exit(0);
 	    }
 
@@ -145,7 +141,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
 	    if(isset($_POST['remove']))
 	    {
-			$scope = $json->decode($_POST['remove']);
+			$scope = json_decode($_POST['remove'], true);
 
 			$lines_to_remove = array();
 			for ($i = $scope[0]; $i <= $scope[1]; $i++)
@@ -164,7 +160,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
 
 
-			echo $json->encode( array('type' => 'success', 'spans' =>
+			echo json_encode( array('type' => 'success', 'spans' =>
 						$dtable->get_spans($dtable_start_line, $page_lines, $dtable_page_id) ) );
 
 		} else
@@ -176,7 +172,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 				if( strpos( $k, 'col' ) === 0)
 				{
 					//remove col from col12, col1 etc. to be 12 1
-					$cols[(int)substr($k, 3)] = $json->decode($v);
+					$cols[(int)substr($k, 3)] = json_decode($v, true);
 				}
 			}
 			ksort($cols);
@@ -216,7 +212,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 			{
 				$action = 'edit';
 
-				$scope = $json->decode($_POST['edit']);
+				$scope = json_decode($_POST['edit'], true);
 
 				$lines_to_change = array();
 				for ($i = $scope[0]; $i <= $scope[1]; $i++)
@@ -240,7 +236,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 			$new_cont = implode( "\n", $page_lines );
 			saveWikiText($dtable_page_id, $new_cont, $info);
 
-			echo $json->encode( array('type' => 'success', 'action' => $action, 'new_row' => $dtable->parse_line($new_line, $dtable_page_id), 'raw_row' => array($new_table_line, array($line_nr, $line_nr)), 'spans' =>  $dtable->get_spans($dtable_start_line, $page_lines, $dtable_page_id) ) );
+			echo json_encode( array('type' => 'success', 'action' => $action, 'new_row' => $dtable->parse_line($new_line, $dtable_page_id), 'raw_row' => array($new_table_line, array($line_nr, $line_nr)), 'spans' =>  $dtable->get_spans($dtable_start_line, $page_lines, $dtable_page_id) ) );
 
 		}
 	break;
@@ -275,12 +271,10 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 	    } else
 		$expire = $conf['locktime'];
 
-	    $json = new JSON();
-
 	    if($checklock === false)
-	       	echo $json->encode(array('locked' => 0, 'time_left' => $expire));
+	       	echo json_encode(array('locked' => 0, 'time_left' => $expire));
 	    else
-	       	echo $json->encode(array('locked' => 1, 'who' => $checklock, 'time_left' => $expire));
+	       	echo json_encode(array('locked' => 1, 'who' => $checklock, 'time_left' => $expire));
 
 	break;
 	}

--- a/action.php
+++ b/action.php
@@ -135,7 +135,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 			exit(0);
 	    }
 
-	    $dtable =& plugin_load('helper', 'dtable');
+	    $dtable = plugin_load('helper', 'dtable');
 
 	    $page_lines = explode( "\n", io_readFile( $file ) );
 

--- a/action.php
+++ b/action.php
@@ -52,7 +52,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 		}
 
 		//it will make include plugin behaves correctly
-		p_set_metadata($INFO['id'], array('dtable_pages' => $dtable_pages), false, false);
+		p_set_metadata($INFO['id'] ?? null, array('dtable_pages' => $dtable_pages), false, false);
 
 		//mark dtables
 		//it will not work becouse section editing in dokuwiki needs no modified content.
@@ -85,13 +85,13 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 			$new_lines[] = $line;
 			}
 			$lines = $new_lines;
-		} 
+		}
 		$event->data = implode("\n", $new_lines);
     }
     function add_php_data(&$event, $param) {
 	global $JSINFO, $ID;
 
-	if (auth_quickaclcheck($ID) >= AUTH_EDIT) 
+	if (auth_quickaclcheck($ID) >= AUTH_EDIT)
 	    $JSINFO['write'] = true;
 	else
 	    $JSINFO['write'] = false;
@@ -116,8 +116,8 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 	$JSINFO['lang']['show_merged_rows'] = $this->getLang('show_merged_rows');
 
 	$JSINFO['lang']['lock_notify'] = str_replace(
-	    array('%u', '%t'), 
-	    array('<span class="who"></span>', '<span class="time_left"></span>'), 
+	    array('%u', '%t'),
+	    array('<span class="who"></span>', '<span class="time_left"></span>'),
 	    $this->getLang('lock_notify'));
 	$JSINFO['lang']['unlock_notify'] = $this->getLang('unlock_notify');
     }
@@ -157,7 +157,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
 			$removed_line = '';
 			foreach ($lines_to_remove as $line) {
-				$removed_line .= $page_lines[ $line ]." "; 
+				$removed_line .= $page_lines[ $line ]." ";
 			}
 
 			array_splice($page_lines, $scope[0], $scope[1] - $scope[0] + 1);
@@ -168,7 +168,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
 
 
-			echo $json->encode( array('type' => 'success', 'spans' =>  
+			echo $json->encode( array('type' => 'success', 'spans' =>
 						$dtable->get_spans($dtable_start_line, $page_lines, $dtable_page_id) ) );
 
 		} else
@@ -228,7 +228,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
 				$old_line= '';
 				foreach ($lines_to_change as $line) {
-					$old_line .= $page_lines[ $line ]." "; 
+					$old_line .= $page_lines[ $line ]." ";
 				}
 
 				//$old_line = $page_lines[ $line_to_change ];
@@ -267,7 +267,7 @@ class action_plugin_dtable extends DokuWiki_Action_Plugin {
 	    $event->stopPropagation();
 
 	    $ID = $_POST['page'];
-	    $checklock = checklock($ID); 
+	    $checklock = checklock($ID);
 
 	    //check when lock expire
 	    $lock_file = wikiLockFN($ID);

--- a/helper.php
+++ b/helper.php
@@ -1,9 +1,5 @@
 <?php
-// must be run within DokuWiki
-if(!defined('DOKU_INC')) die();
 
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'syntax.php';
 require_once DOKU_INC.'inc/parser/parser.php';
 
 /**

--- a/helper.php
+++ b/helper.php
@@ -14,8 +14,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
     function error($code, $json=false)
     {
 		if($json == true) {
-			$json = new JSON();
-			return $json->encode(array('type' => 'error', 'msg' => $this->getLang($code)));
+			return json_encode(array('type' => 'error', 'msg' => $this->getLang($code)));
 		} else {
 			return $this->getLang($code);
 		}

--- a/helper.php
+++ b/helper.php
@@ -27,7 +27,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 
     static function line_nr($pos, $file_path, $start_line = 0) {
 		$line_nr = 0;
-		if (!is_array(self::$line_nr_c[$file_path])) {
+		if (!is_array(self::$line_nr_c[$file_path] ?? null)) {
 			self::$line_nr_c[$file_path] = array();
 			$start_pos = 0;
 			$line_nr = 0;
@@ -38,7 +38,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 
 		if ($start_line > 0) {
 			//find last pos on current line
-			if (($find = array_search($start_line, self::$line_nr_c[$file_path])) !== false) {
+			if (($find = array_search($start_line, self::$line_nr_c[$file_path] ?? [])) !== false) {
 				//the new line charter from last line -> it's nessesery in order to corect work of my handler
 				$start_pos = $find;
 				$pos += $find;

--- a/helper.php
+++ b/helper.php
@@ -25,7 +25,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 		}
     }
 
-    function line_nr($pos, $file_path, $start_line = 0) {
+    static function line_nr($pos, $file_path, $start_line = 0) {
 		$line_nr = 0;
 		if (!is_array(self::$line_nr_c[$file_path])) {
 			self::$line_nr_c[$file_path] = array();

--- a/helper.php
+++ b/helper.php
@@ -108,6 +108,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 		return $spans;
 	}
     function format_row($array_line) {
+        $line = '';
 		foreach ($array_line as $cell)
 		{
 			if ($cell[0] == 'tableheader_open')

--- a/helper.php
+++ b/helper.php
@@ -44,7 +44,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 				$pos += $find;
 			} else {
 				if (self::$file_cont == NULL)
-					self::$file_cont = io_readFile($file_path);	
+					self::$file_cont = io_readFile($file_path);
 
 				for($i = $start_pos; $i < strlen(self::$file_cont) && $line_nr < $start_line; $i++) {
 					self::$line_nr_c[$file_path][$i] = $line_nr;
@@ -65,7 +65,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 			return self::$line_nr_c[$file_path][$pos];
 		} else {
 			if (self::$file_cont == NULL)
-				self::$file_cont = io_readFile($file_path);	
+				self::$file_cont = io_readFile($file_path);
 
 			for($i=$start_pos;$i <= $pos; $i++)
 			{
@@ -89,7 +89,7 @@ class helper_plugin_dtable extends dokuwiki_plugin
 		}
 
 		return $Parser->parse($row);
-		
+
 	}
 	function get_spans($start_line, $page_lines, $page_id) {
 		$table = '';
@@ -152,7 +152,7 @@ class helper_plugin_dtable_handler {
 	public $type;
 	public $file_path;
 	public $start_line;
-	
+
 	public function __construct($page_id, $start_line) {
 		$this->file_path = wikiFN($page_id);
 		$this->start_line = $start_line;
@@ -245,6 +245,10 @@ class helper_plugin_dtable_handler {
 	* @return bool If parsing should be continue
 	*/
     public function __call($name, $params) {
+        if($this->calls === null) $this->calls = [];
+        if(!isset($this->calls[$this->row][0][$this->cell][3])) {
+            $this->calls[$this->row][0][$this->cell][3] = '';
+        }
 		$this->calls[$this->row][0][$this->cell][3] .= $params[0];
 		return true;
     }

--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ dtable.page_locked = 0;
 
 //state of lock
 //0 -> we don't know anything
-//1 -> someone lock the page and we waiting until we could refresh it 
+//1 -> someone lock the page and we waiting until we could refresh it
 //2 -> we can edit page for some time but we left browser alone and our lock expires and someone else came end start to edit page, so we need to lock our page and optionally send the form.
 dtable.lock_state = 0;
 
@@ -55,7 +55,7 @@ dtable.error = function(msg)
 };
 dtable.show_form = function($table)
 {
-    var $form = $table.find(".form_row"); 
+    var $form = $table.find(".form_row");
     var $toolbar = jQuery("#"+dtable.toolbar_id);
 
     //display fix jquery 1.6 bug
@@ -66,7 +66,7 @@ dtable.show_form = function($table)
 	$form.find("textarea.dtable_field").each(function() {
 
 		//this is merged cell
-		var button = jQuery(this).closest('td').find('button'); 
+		var button = jQuery(this).closest('td').find('button');
 		if (button.length > 0)
 		{
 			var button_width = 31;
@@ -86,18 +86,18 @@ dtable.show_form = function($table)
 		jQuery(this).css('top', textarea_offset.top - this_texta_offset.top);
 	});
 
-	
+
 
     var offset = $form.offset();
     $toolbar.css({
-	"left": offset.left, 
+	"left": offset.left,
 	"top": offset.top-$toolbar.height()
     });
     $toolbar.show();
 };
 dtable.hide_form = function($table)
 {
-    var $form = $table.find(".form_row"); 
+    var $form = $table.find(".form_row");
 	//remove form
 	$form.remove();
 	//remove textareas in rowspans
@@ -125,7 +125,7 @@ dtable.get_call = function($form)
 //Lock actuall page
 dtable.lock = function()
 {
-  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', 
+  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',
   {
       'call': 'dtable_page_lock',
       'page': JSINFO['id'],
@@ -135,7 +135,7 @@ dtable.unlock = function()
 {
   if(dtable.page_locked == 1)
   {
-      jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', 
+      jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',
       {
 	  'call': 'dtable_page_unlock',
 	  'page': JSINFO['id'],
@@ -165,7 +165,7 @@ dtable.panlock_switch = function(state)
 
 dtable.lock_seeker = function(nolock, lock)
 {
-  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', 
+  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',
   {
       'call': 'dtable_is_page_locked',
       'page': JSINFO['id'],
@@ -235,7 +235,7 @@ dtable.unlock_dtable = function()
    jQuery(document).bind('mousemove', function(e){
        dtable.pageX = e.pageX;
        dtable.pageY = e.pageY;
-   }); 
+   });
 
 
 
@@ -265,12 +265,15 @@ dtable.unlock_dtable = function()
     });
 
     jQuery(document).dblclick(function(e){
-	    //sent form only once
+        //sent form only once
 	    if(dtable.form_processing == false) {
 			dtable.form_processing = true;
 			//$context_menu.hide();
-			if(jQuery(".dtable .form_row").find(":visible").length > 0)
-				jQuery(".dtable").submit();
+			if(jQuery(".dtable .form_row").find(":visible").length > 0) {
+                jQuery(".dtable").submit();
+            } else {
+                dtable.form_processing = false;
+            }
 	    }
     });
 };
@@ -280,7 +283,7 @@ dtable.lock_dtable = function()
 
     jQuery(document).unbind('mousemove');
     $row.find("td, th").unbind('contextmenu');
-    
+
     jQuery("#dtable_context_menu").hide();
 };
 
@@ -289,7 +292,7 @@ dtable.row_mousedown = function(e) {
     var $this_row = $this_cell.closest("tr");
 
     var $context_menu = jQuery("#dtable_context_menu");
-	
+
     $context_menu.html('');
 	switch(this.nodeName.toLowerCase())
 	{
@@ -319,7 +322,7 @@ dtable.row_mousedown = function(e) {
 	$context_menu.find("li.insert_col_left").addClass("separator");
 	$context_menu.find("li.mark_row_as_header").addClass("separator");
 
-	
+
     var offsetX = e.pageX + 1;
     var offsetY = e.pageY + 1;
 
@@ -357,7 +360,7 @@ dtable.change_rows = function($table, spans)
 			}
 		});
 	});
-	
+
 };
 
 dtable.get_table_id = function($form)
@@ -374,7 +377,7 @@ dtable.new_build_form = function($form, $row, action, value, row_data, colspan_c
    	{
 		jQuery($form).find("input.dtable_field.dtable_action").attr("name", action).val(JSON.stringify(value));
 		jQuery($form).find("input.dtable_field[name=table]").val(dtable.get_table_id($form));
-						
+
 	} else
    	{
 		//append dtable_action
@@ -421,9 +424,9 @@ dtable.new_build_form = function($form, $row, action, value, row_data, colspan_c
 				var tclass = 'tablecell_open';
 				break;
 		}
-		var colspan = cells[i][0]; 
-		var rowspan = cells[i][1]; 
-		var content = cells[i][3]; 
+		var colspan = cells[i][0];
+		var rowspan = cells[i][1];
+		var content = cells[i][3];
 
 		var $father_cell = $row.find("td, th").eq(td_index);
 		//var rowspan = $father_cell.attr('rowspan');
@@ -501,7 +504,7 @@ dtable.remove = function($this_row) {
 	$table = $form.find("table");
 
 	var id = dtable.get_row_id($table, $this_row);
-	  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', 
+	  jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',
 	  {
 	      'call': dtable.get_call($form),
 	      'table': dtable.get_table_id($form),
@@ -541,7 +544,7 @@ dtable.remove = function($this_row) {
 dtable.contex_handler = function(e) {
     e.preventDefault();
 
-	var insert_colspan_callback = 
+	var insert_colspan_callback =
 				function($form_row, colspan,  width, height, tclass, col) {
 					width /= colspan;
 					for (var j = 0; j < colspan; j++)
@@ -550,7 +553,7 @@ dtable.contex_handler = function(e) {
 						col++;
 					}
 					return col;
-				}; 
+				};
 
     $this_row = dtable.row;
     dtable.id = $this_row.closest(".dtable").attr("id");
@@ -627,7 +630,7 @@ dtable.contex_handler = function(e) {
 		$this_row.after($table.find(".form_row"));
 
 		$this_row.hide();
-		dtable.show_form($table);  
+		dtable.show_form($table);
 
 	break;
 	case '#insert_after':
@@ -636,7 +639,7 @@ dtable.contex_handler = function(e) {
 		var rows_data = $form.data("table");
 		var rows = rows_data[row_id];
 
-		dtable.new_build_form($form, $this_row, "add", rows[1][1], rows, 
+		dtable.new_build_form($form, $this_row, "add", rows[1][1], rows,
 				insert_colspan_callback,
 				function(cclass, rowspan, colspan, value)
 			    {
@@ -654,7 +657,7 @@ dtable.contex_handler = function(e) {
 		var $form_row = $table.find(".form_row");
 
 		$this_row.after($form_row);
-		dtable.show_form($table);  
+		dtable.show_form($table);
 	break;
 	case '#insert_before':
 
@@ -677,7 +680,7 @@ dtable.contex_handler = function(e) {
 		var rows = rows_data[dtable.get_row_id($table, $this_row)];
 
 		if (first_elm == true) {
-			var mod_row_call = 
+			var mod_row_call =
 				function(cclass, rowspan, colspan, value)
 			    {
 					if (jQuery.trim(value) !== ':::')
@@ -691,7 +694,7 @@ dtable.contex_handler = function(e) {
 					return [cclass, rowspan, colspan, value];
 			    };
 		} else {
-			var mod_row_call = 
+			var mod_row_call =
 				function(cclass, rowspan, colspan, value)
 			    {
 					if (jQuery.trim(value) !== ':::')
@@ -706,11 +709,11 @@ dtable.contex_handler = function(e) {
 			    };
 		}
 
-		dtable.new_build_form($form, $this_row, "add", add, rows, 
+		dtable.new_build_form($form, $this_row, "add", add, rows,
 				insert_colspan_callback, mod_row_call);
 
 		$this_row.before($table.find(".form_row"));
-		dtable.show_form($table);  
+		dtable.show_form($table);
 	break;
     }
     jQuery(this).closest("#dtable_context_menu").hide();
@@ -731,7 +734,7 @@ dtable.intervals.push(setInterval(function()
     dtable.lock_expires -= 1;
     if(dtable.lock_expires <= -1)
 	return;
-    
+
     if(dtable.lock_expires === 0)
     {
 	//we had own lock
@@ -749,7 +752,7 @@ dtable.intervals.push(setInterval(function()
 	    //after submitting form
 	    dtable.lock_dtable();
 	    dtable.panlock_switch('panunlock');
-	} else 
+	} else
 	{
 	    //unblock us if someones lock expires
 	    dtable.lock_seeker();
@@ -816,14 +819,14 @@ jQuery(".dtable").submit(
 				});
 
 			if (any_data == true) {
-				jQuery.post(DOKU_BASE + 'lib/exe/ajax.php', 
+				jQuery.post(DOKU_BASE + 'lib/exe/ajax.php',
 						data,
 				function(data)
 				{
 					  var res = jQuery.parseJSON(data);
 					  if(res.type == 'success')
 					  {
-						  
+
 						  if( res.new_row !== undefined )
 						  {
 							  //remove old element
@@ -840,7 +843,7 @@ jQuery(".dtable").submit(
 								  $new_elm.find("td, th").bind("contextmenu", dtable.row_mousedown);
 
 							  var index = dtable.get_row_id($table, $new_elm);
-							  
+
 							  var raw_rows = $form.data('table');
 
 							  if (res.action == 'edit') {
@@ -883,6 +886,7 @@ jQuery(".dtable").submit(
 				dtable.form_processing = false;
 			}
 	    }
+       dtable.form_processing = false;
 	   return false;
 	});
 jQuery(".dtable").delegate('textarea.dtable_field', 'focus', function(e) {
@@ -895,7 +899,7 @@ jQuery(".dtable").delegate('textarea.dtable_field', 'focus', function(e) {
 
 	$marked_parent = $marked_textarea.parent();
 	$this_parent = jQuery(this).parent();
-	
+
 	this_val = jQuery(this).val();
 	marked_val = $marked_textarea.val();
 	jQuery(this).val(marked_val);
@@ -916,13 +920,13 @@ jQuery(".dtable").delegate('textarea.dtable_field', 'focus', function(e) {
 
 	this_height = jQuery(this).height();
 	marked_height = $marked_textarea.height();
-	
+
 	//get styles
 	var this_style = jQuery(this).getStyleObject(['position', 'top', 'left', 'display']);
 	var marked_style = $marked_textarea.getStyleObject(['position', 'top', 'left', 'display']);
 	jQuery(this).css(marked_style);
 	$marked_textarea.css(this_style);
-	
+
 
 	//correct width and height
 	jQuery(this).width(marked_width);
@@ -930,7 +934,7 @@ jQuery(".dtable").delegate('textarea.dtable_field', 'focus', function(e) {
 
 	jQuery(this).height(marked_height);
 	$marked_textarea.height(this_height);
-	
+
 
 	$marked_parent.append(jQuery(this));
 	$this_parent.append($marked_textarea);

--- a/syntax.php
+++ b/syntax.php
@@ -81,9 +81,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 
 			$lines = $dtable->rows($raw_lines, $id, $start_line);
 
-			$json = new JSON();
-
-			$renderer->doc .= '<form class="dtable dynamic_form" id="dtable_'.$start_line.'_'.$id.'" action="'.DOKU_BASE.'lib/exe/ajax.php" method="post" data-table="'.htmlspecialchars($json->encode($lines)).'">';
+			$renderer->doc .= '<form class="dtable dynamic_form" id="dtable_'.$start_line.'_'.$id.'" action="'.DOKU_BASE.'lib/exe/ajax.php" method="post" data-table="'.htmlspecialchars(json_encode($lines)).'">';
 			$renderer->doc .= '<input type="hidden" class="dtable_field" value="dtable" name="call">';
 
 			//This is needed to correct linkwiz behaviour.

--- a/syntax.php
+++ b/syntax.php
@@ -49,7 +49,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 		{
 		    if (auth_quickaclcheck($ID) >= AUTH_EDIT)
 		    {
-			$dtable =& plugin_load('helper', 'dtable');
+			$dtable = plugin_load('helper', 'dtable');
 
 			$pos = $match[0];
 			$table_nr = $match[1];

--- a/syntax.php
+++ b/syntax.php
@@ -89,7 +89,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 
 			$json = new JSON();
 
-			$renderer->doc .= '<form class="dtable dynamic_form" id="dtable_'.$start_line.'_'.$id.'" action="'.$DOKU_BASE.'lib/exe/ajax.php" method="post" data-table="'.htmlspecialchars($json->encode($lines)).'">';
+			$renderer->doc .= '<form class="dtable dynamic_form" id="dtable_'.$start_line.'_'.$id.'" action="'.DOKU_BASE.'lib/exe/ajax.php" method="post" data-table="'.htmlspecialchars($json->encode($lines)).'">';
 			$renderer->doc .= '<input type="hidden" class="dtable_field" value="dtable" name="call">';
 
 			//This is needed to correct linkwiz behaviour.

--- a/syntax.php
+++ b/syntax.php
@@ -1,10 +1,4 @@
 <?php
-// must be run within DokuWiki
-if(!defined('DOKU_INC')) die();
-
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once DOKU_PLUGIN.'syntax.php';
-
 
 /**
  * All DokuWiki plugins to extend the parser/rendering mechanism

--- a/syntax.php
+++ b/syntax.php
@@ -31,7 +31,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
           case DOKU_LEXER_ENTER :
 	      try {
 		  		$table_nr = (int) substr($match, 5, 2);
-                return array($state, array($pos, $table_nr, p_get_metadata($INFO['id'] ?? $ID, 'dtable_pages')));
+                return array($state, array($pos, $table_nr, p_get_metadata($INFO['id'] ?? null, 'dtable_pages')));
 	      } catch(Exception $e)
 	      {
 		  return array($state, false);

--- a/syntax.php
+++ b/syntax.php
@@ -18,7 +18,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 
     function getType() { return 'container'; }
     function getSort() { return 400; }
-    function getAllowedTypes() {return array('container','formatting','substition');} 
+    function getAllowedTypes() {return array('container','formatting','substition');}
 
     function connectTo($mode) { $this->Lexer->addEntryPattern('<dtab[0-9][0-9]>(?=.*</dtable>)',$mode,'plugin_dtable'); }
     function postConnect() { $this->Lexer->addExitPattern('</dtable>','plugin_dtable'); }
@@ -26,16 +26,17 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 
     function handle($match, $state, $pos, Doku_Handler $handler) {
 		global $INFO;
+        global $ID;
         switch ($state) {
           case DOKU_LEXER_ENTER :
 	      try {
 		  		$table_nr = (int) substr($match, 5, 2);
-                return array($state, array($pos, $table_nr, p_get_metadata($INFO['id'], 'dtable_pages')));
+                return array($state, array($pos, $table_nr, p_get_metadata($INFO['id'] ?? $ID, 'dtable_pages')));
 	      } catch(Exception $e)
 	      {
 		  return array($state, false);
 	      }
- 
+
           case DOKU_LEXER_UNMATCHED :  return array($state, $match);
           case DOKU_LEXER_EXIT :       return array($state, '');
         }
@@ -48,11 +49,11 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 	{
 	   list($state,$match) = $data;
 	   switch ($state) {
-	     case DOKU_LEXER_ENTER :     
+	     case DOKU_LEXER_ENTER :
 
 		if($match != false)
 		{
-		    if (auth_quickaclcheck($ID) >= AUTH_EDIT) 
+		    if (auth_quickaclcheck($ID) >= AUTH_EDIT)
 		    {
 			$dtable =& plugin_load('helper', 'dtable');
 
@@ -65,7 +66,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 
 			$start_line = $dtable->line_nr($pos, $filepath) ;
 
-			//search for first row 
+			//search for first row
 			$file_cont = explode("\n", io_readWikiPage($filepath, $id));
 
 			$start_line++;
@@ -99,10 +100,10 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
 	    break;
 
 	    case DOKU_LEXER_UNMATCHED :  $renderer->doc .= $renderer->_xmlEntities($match); break;
-	    case DOKU_LEXER_EXIT :     
-		if (auth_quickaclcheck($ID) >= AUTH_EDIT) 
-		    $renderer->doc .= "</form>"; 
-		
+	    case DOKU_LEXER_EXIT :
+		if (auth_quickaclcheck($ID) >= AUTH_EDIT)
+		    $renderer->doc .= "</form>";
+
 	    break;
 	   }
 	   return true;


### PR DESCRIPTION
This should reinstate Kaos and PHP 8 compability. Most of these fixes are merely cosmetical workarounds than proper fixes for the underlying issues. See individual commits for details.

The code would need a major refactoring to actually fix the issues. That however was beyond the scope our client paid for.